### PR TITLE
feat: simplify estimator options

### DIFF
--- a/mgfencing-2/api/prices.json
+++ b/mgfencing-2/api/prices.json
@@ -1,0 +1,9 @@
+{
+  "taxRate": 0.13,
+  "products": {
+    "privacy": {"material": 30, "gate": 35},
+    "vinyl": {"material": 35, "gate": 40},
+    "chainlink": {"material": 20, "gate": 25},
+    "wrought_iron": {"material": 50, "gate": 50}
+  }
+}

--- a/mgfencing-2/estimate.html
+++ b/mgfencing-2/estimate.html
@@ -12,7 +12,6 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" />
   <!-- Global styles for animations, forms and footers -->
   <link rel="stylesheet" href="css/global.css" />
-  <!-- Remove inline fade styles and scripts; handled by global CSS/JS -->
 </head>
 <body>
   <!-- Top Bar -->
@@ -60,81 +59,104 @@
     </div>
   </section>
   <!-- ESTIMATOR SECTION -->
-  <main class="max-w-3xl mx-auto px-6 py-16">
-    <div class="bg-white p-8 rounded-xl shadow-md space-y-6">
-      <div>
-        <label class="block mb-2 font-medium">Fence Type</label>
-        <select id="type" class="w-full p-3 border rounded">
-          <option value="picket">Picket (Wood)</option>
-          <option value="privacy">Privacy</option>
-          <option value="vinyl">Vinyl</option>
-          <option value="chainlink">Chain-link</option>
-          <option value="wrought_iron">Wrought Iron</option>
-          <option value="guide_rail">High Cable Guide Rail Tension</option>
-          <option value="cable_rail">Cable Guide Rail</option>
-          <option value="steel_rail">Steel Beam Guide Rail</option>
-        </select>
-      </div>
-      <!-- Height Selection -->
-      <div id="height-section">
-        <label class="block mb-2 font-medium">Height (ft) <span class="text-red-600">*</span></label>
-        <div class="flex space-x-6">
-          <label class="inline-flex items-center"><input type="radio" name="height" value="3" required class="form-radio text-green-600" /><span class="ml-2">3ft</span></label>
-          <label class="inline-flex items-center"><input type="radio" name="height" value="4" class="form-radio text-green-600" /><span class="ml-2">4ft</span></label>
-          <label class="inline-flex items-center"><input type="radio" name="height" value="5" class="form-radio text-green-600" /><span class="ml-2">5ft</span></label>
-          <label class="inline-flex items-center"><input type="radio" name="height" value="6" class="form-radio text-green-600" /><span class="ml-2">6ft</span></label>
+  <main class="max-w-6xl mx-auto px-6 py-16">
+    <div class="md:flex md:space-x-8">
+      <form id="estimator-form" class="bg-white p-8 rounded-xl shadow-md space-y-6 md:flex-1" novalidate>
+        <div>
+          <label for="category" class="block mb-2 font-medium" title="Select fence type">Product Category</label>
+          <select id="category" class="w-full p-3 border rounded" aria-describedby="category-tip">
+            <option value="privacy">Privacy Fence</option>
+            <option value="vinyl">Vinyl Fencing</option>
+            <option value="chainlink">Chain Link</option>
+            <option value="wrought_iron">Wrought Iron</option>
+          </select>
+          <p id="category-tip" class="text-sm text-gray-500">Choose your fence type.</p>
         </div>
-      </div>
-      <div>
-        <label class="block mb-2 font-medium">Perimeter Length (ft)</label>
-        <input id="length" type="number" min="10" placeholder="Min 10 ft, e.g. 150" class="w-full p-3 border rounded" />
-      </div>
-      <div id="color-option" class="hidden"><label class="block mb-2 font-medium">Chain-link Color</label><select id="chain-color" class="w-full p-3 border rounded"><option value="galvanized">Galvanized</option><option value="black">Black Coated</option><option value="brown">Brown Coated</option><option value="green">Green Coated</option></select></div>
-      <div id="slat-option" class="hidden"><label class="inline-flex items-center"><input type="checkbox" id="privacy-slats" class="form-checkbox text-green-600" /><span class="ml-2">Include Privacy Slats (+extra cost)</span></label></div>
-      <div id="gate-option" class="hidden"><label class="block mb-2 font-medium">Number of Gates</label><input id="gate-count" type="number" min="0" placeholder="e.g. 2" class="w-full p-3 border rounded" /></div>
-      <button id="calculate" class="w-full bg-green-600 text-white py-2 px-4 rounded-lg hover:bg-green-700 transition">Calculate Estimate</button>
-      <div id="result" class="text-xl font-semibold text-center mt-4"></div>
+
+        <div id="height-wrapper">
+          <label for="height" class="block mb-2 font-medium">Height (ft)</label>
+          <input type="range" id="height" min="3" max="6" step="1" value="4" class="w-full" aria-describedby="height-tip" />
+          <div class="text-sm text-gray-600" id="height-value">4ft</div>
+          <p id="height-tip" class="sr-only">Use slider to select height.</p>
+        </div>
+
+        <div>
+          <label for="length" class="block mb-2 font-medium" title="Total perimeter length">Perimeter Length (ft)</label>
+          <input id="length" type="number" min="10" placeholder="Min 10 ft, e.g. 150" class="w-full p-3 border rounded" aria-describedby="length-tip length-error" />
+          <p id="length-tip" class="text-sm text-gray-500">Total length of fencing needed.</p>
+          <p id="length-error" class="text-sm text-red-600 hidden" role="alert"></p>
+        </div>
+
+        <div id="chainlink-options" class="hidden space-y-4">
+          <div>
+            <label for="chain-color" class="block mb-2 font-medium">Chain-link Color</label>
+            <select id="chain-color" class="w-full p-3 border rounded">
+              <option value="galvanized">Galvanized</option>
+              <option value="black">Black Coated</option>
+              <option value="brown">Brown Coated</option>
+              <option value="green">Green Coated</option>
+            </select>
+          </div>
+          <div>
+            <label class="inline-flex items-center">
+              <input type="checkbox" id="slats" class="form-checkbox text-green-600" />
+              <span class="ml-2">Privacy Slats</span>
+            </label>
+          </div>
+        </div>
+
+        <div id="vinyl-options" class="hidden">
+          <label class="inline-flex items-center">
+            <input type="checkbox" id="vinyl-slats" class="form-checkbox text-green-600" />
+            <span class="ml-2">Add Decorative Slats</span>
+          </label>
+        </div>
+
+        <div id="gate-section" class="hidden space-y-4">
+          <label class="block font-medium">Gates</label>
+          <div class="grid md:grid-cols-3 gap-4">
+            <div>
+              <label for="gate-count" class="block text-sm">Number</label>
+              <input id="gate-count" type="number" min="0" value="0" class="w-full p-2 border rounded" />
+            </div>
+            <div>
+              <label for="gate-type" class="block text-sm">Type</label>
+              <select id="gate-type" class="w-full p-2 border rounded">
+                <option value="swing">Swing</option>
+                <option value="slide">Slide</option>
+              </select>
+            </div>
+            <div>
+              <label for="gate-width" class="block text-sm">Width (ft)</label>
+              <input id="gate-width" type="number" min="3" value="3" class="w-full p-2 border rounded" />
+            </div>
+          </div>
+          <label class="inline-flex items-center">
+            <input type="checkbox" id="gate-auto" class="form-checkbox text-green-600" />
+            <span class="ml-2">Automation</span>
+          </label>
+        </div>
+
+        <button type="submit" class="w-full bg-green-600 text-white py-2 px-4 rounded-lg hover:bg-green-700 transition">Update Estimate</button>
+      </form>
+
+      <aside id="summary" class="mt-8 md:mt-0 md:w-1/3 bg-gray-50 p-6 rounded-xl shadow space-y-2" aria-live="polite">
+        <h2 class="text-xl font-semibold mb-4">Cost Summary</h2>
+        <p>Materials: $<span data-materials>0.00</span></p>
+        <p class="font-bold">Total: $<span data-total>0.00</span></p>
+        <p class="mt-4 text-sm text-gray-600">Posts needed: <span data-posts>0</span>, Rails needed: <span data-rails>0</span></p>
+      </aside>
     </div>
   </main>
   <!-- FOOTER -->
   <footer>
     <div class="max-w-6xl mx-auto px-6 text-center space-y-2">
       <p>M&amp;G Fencing Inc. | Serving Ontario, Canada | 826 Bruno St, Azilda ON | <a href="mailto:fencing@mgfencing.ca" class="underline">fencing@mgfencing.ca</a> | <a href="tel:+17059834411" class="underline">(705) 983-4411</a></p>
-      <!-- Use data-year for automatic copyright year injection -->
       <p>&copy; <span data-year></span> M&amp;G Fencing Inc. All rights reserved.</p>
     </div>
   </footer>
   <!-- Load core functionality (fades, nav toggle, section reveal, dynamic year) -->
   <script src="js/main.js"></script>
-  <script>
-    // Options toggle
-    const typeSelect = document.getElementById('type'), colorOpt = document.getElementById('color-option'), slatOpt = document.getElementById('slat-option'), gateOpt = document.getElementById('gate-option'), heightSec = document.getElementById('height-section');
-    function updateOptions(){
-      const val=typeSelect.value;
-      colorOpt.classList.toggle('hidden', val!=='chainlink');
-      if(val==='privacy') slatOpt.classList.add('hidden');
-      else if(['vinyl','chainlink'].includes(val)) slatOpt.classList.remove('hidden');
-      else { slatOpt.classList.add('hidden'); document.getElementById('privacy-slats').checked=false; }
-      gateOpt.classList.toggle('hidden', !['picket','privacy','chainlink','vinyl'].includes(val));
-      if(gateOpt.classList.contains('hidden')) document.getElementById('gate-count').value='';
-      heightSec.classList.toggle('hidden',['guide_rail','cable_rail','steel_rail'].includes(val));
-      if(heightSec.classList.contains('hidden')) document.querySelectorAll('input[name="height"]').forEach(r=>r.checked=false);
-    }
-    typeSelect.addEventListener('change', updateOptions); updateOptions();
-
-    // Calculation with height & min length
-    document.getElementById('calculate').addEventListener('click', ()=>{
-      const length=parseFloat(document.getElementById('length').value)||0;
-      if(length<10) return alert('Please enter at least 10 ft of perimeter.');
-      const height=parseFloat(document.querySelector('input[name="height"]:checked')?.value)||4;
-      const mult={3:0.75,4:1,5:1.25,6:1.5}[height];
-      const rates={picket:25,privacy:25,vinyl:30,chainlink:20,wrought_iron:50,guide_rail:45,cable_rail:40,steel_rail:50};
-      let rate=rates[typeSelect.value]*mult;
-      if(['vinyl','chainlink'].includes(typeSelect.value)&&document.getElementById('privacy-slats').checked) rate+=5*mult;
-      const gates=parseInt(document.getElementById('gate-count').value)||0;
-      let cost=rate*length + gates*250;
-      document.getElementById('result').textContent=`Estimated Cost: ${cost.toLocaleString('en-CA',{style:'currency',currency:'CAD'})}`;
-    });
-  </script>
+  <script type="module" src="js/estimator.js"></script>
 </body>
 </html>

--- a/mgfencing-2/js/estimator.js
+++ b/mgfencing-2/js/estimator.js
@@ -1,0 +1,96 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('estimator-form');
+  const category = document.getElementById('category');
+  const lengthInput = document.getElementById('length');
+  const heightRange = document.getElementById('height');
+  const heightValue = document.getElementById('height-value');
+  const chainOptions = document.getElementById('chainlink-options');
+  const vinylOptions = document.getElementById('vinyl-options');
+  const gateSection = document.getElementById('gate-section');
+  const gateCount = document.getElementById('gate-count');
+  const gateWidth = document.getElementById('gate-width');
+  const gateAuto = document.getElementById('gate-auto');
+  const summary = document.getElementById('summary');
+  const lengthError = document.getElementById('length-error');
+
+  let prices = { taxRate: 0, products: {} };
+
+  fetch('api/prices.json')
+    .then(r => r.json())
+    .then(data => { prices = data; update(); });
+
+  function toggleSections() {
+    const val = category.value;
+    chainOptions.classList.toggle('hidden', val !== 'chainlink');
+    vinylOptions.classList.toggle('hidden', val !== 'vinyl');
+    gateSection.classList.toggle('hidden', !['privacy','vinyl','chainlink','wrought_iron'].includes(val));
+  }
+  category.addEventListener('change', () => { toggleSections(); update(); });
+
+  heightRange.addEventListener('input', () => {
+    heightValue.textContent = `${heightRange.value}ft`;
+    update();
+  });
+
+  [lengthInput, gateCount, gateWidth, gateAuto, document.getElementById('slats'), document.getElementById('vinyl-slats'), document.getElementById('chain-color'), document.getElementById('gate-type')].forEach(el => {
+    if (el) el.addEventListener('input', update);
+  });
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    update();
+  });
+
+  function update() {
+    const length = parseFloat(lengthInput.value);
+    if (!length || length < 10) {
+      lengthError.textContent = 'Minimum perimeter is 10 ft';
+      lengthError.classList.remove('hidden');
+      lengthInput.setAttribute('aria-invalid', 'true');
+      summary.querySelector('[data-materials]').textContent = '0.00';
+      summary.querySelector('[data-total]').textContent = '0.00';
+      summary.querySelector('[data-posts]').textContent = '0';
+      summary.querySelector('[data-rails]').textContent = '0';
+      return;
+    }
+    lengthError.classList.add('hidden');
+    lengthInput.removeAttribute('aria-invalid');
+
+    const product = category.value;
+    const info = prices.products[product] || {};
+    const materialRate = info.material || 0;
+    const height = parseInt(heightRange.value, 10) || 4;
+    const mult = {3:0.75,4:1,5:1.25,6:1.5}[height] || 1;
+    let materialCost = materialRate * mult * length;
+
+    if (product === 'chainlink' && document.getElementById('slats').checked) {
+      materialCost += 5 * mult * length;
+    }
+    if (product === 'vinyl' && document.getElementById('vinyl-slats').checked) {
+      materialCost += 7 * mult * length;
+    }
+
+    const gates = parseInt(gateCount.value) || 0;
+    const gateWidthVal = parseFloat(gateWidth.value) || 0;
+    if (gates > 0) {
+      const gateRate = info.gate || 0;
+      materialCost += gates * gateWidthVal * gateRate;
+      if (gateAuto.checked) {
+        materialCost += gates * 1000;
+      }
+    }
+
+    const posts = Math.ceil(length / 8) + 1;
+    const rails = posts * 2;
+    const tax = materialCost * (prices.taxRate || 0);
+    const total = materialCost + tax;
+
+    summary.querySelector('[data-materials]').textContent = materialCost.toFixed(2);
+    summary.querySelector('[data-total]').textContent = total.toFixed(2);
+    summary.querySelector('[data-posts]').textContent = posts;
+    summary.querySelector('[data-rails]').textContent = rails;
+  }
+
+  toggleSections();
+  update();
+});


### PR DESCRIPTION
## Summary
- streamline product categories to privacy, vinyl, chain link, and wrought iron fences
- drop labour breakdown and guard rail pricing; summary now shows materials and total only
- keep dynamic pricing feed and responsive sidebar updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689125d00640833390ac632e52e6cc34