### PR TITLE
Allow 8ft height, colored chain-link, and gate options for all products

### DIFF
--- a/mgfencing-2/api/prices.json
+++ b/mgfencing-2/api/prices.json
@@ -3,7 +3,7 @@
   "products": {
     "privacy": {"material": 30, "gate": 35},
     "vinyl": {"material": 35, "gate": 40},
-    "chainlink": {"material": 20, "gate": 25},
+    "chainlink": {"material": 20, "materialColored": 25, "gate": 25},
     "wrought_iron": {"material": 50, "gate": 50}
   }
 }

--- a/mgfencing-2/estimate.html
+++ b/mgfencing-2/estimate.html
@@ -76,7 +76,7 @@
 
         <div id="height-wrapper">
           <label for="height" class="block mb-2 font-medium">Height (ft)</label>
-          <input type="range" id="height" min="3" max="6" step="1" value="4" class="w-full" aria-describedby="height-tip" />
+          <input type="range" id="height" min="4" max="8" step="1" value="4" class="w-full" aria-describedby="height-tip" />
           <div class="text-sm text-gray-600" id="height-value">4ft</div>
           <p id="height-tip" class="sr-only">Use slider to select height.</p>
         </div>
@@ -113,39 +113,66 @@
           </label>
         </div>
 
-        <div id="gate-section" class="hidden space-y-4">
-          <label class="block font-medium">Gates</label>
-          <div class="grid md:grid-cols-3 gap-4">
-            <div>
-              <label for="gate-count" class="block text-sm">Number</label>
-              <input id="gate-count" type="number" min="0" value="0" class="w-full p-2 border rounded" />
-            </div>
-            <div>
-              <label for="gate-type" class="block text-sm">Type</label>
-              <select id="gate-type" class="w-full p-2 border rounded">
-                <option value="swing">Swing</option>
-                <option value="slide">Slide</option>
-              </select>
-            </div>
-            <div>
-              <label for="gate-width" class="block text-sm">Width (ft)</label>
-              <input id="gate-width" type="number" min="3" value="3" class="w-full p-2 border rounded" />
-            </div>
-          </div>
+        <div id="gate-question">
           <label class="inline-flex items-center">
-            <input type="checkbox" id="gate-auto" class="form-checkbox text-green-600" />
-            <span class="ml-2">Automation</span>
+            <input type="checkbox" id="has-gates" class="form-checkbox text-green-600" />
+            <span class="ml-2">Include Gates?</span>
           </label>
         </div>
 
-        <button type="submit" class="w-full bg-green-600 text-white py-2 px-4 rounded-lg hover:bg-green-700 transition">Update Estimate</button>
+        <div id="gate-section" class="hidden">
+          <fieldset class="border rounded-lg p-4 space-y-4">
+            <legend class="font-medium px-2">Gate Details</legend>
+            <div class="grid md:grid-cols-2 gap-4">
+              <div>
+                <label for="gate-count" class="block text-sm text-gray-700">Number of Gates</label>
+                <input id="gate-count" type="number" min="0" value="0" class="mt-1 w-full p-2 border rounded" />
+              </div>
+              <div>
+                <label for="gate-type" class="block text-sm text-gray-700">Gate Type</label>
+                <select id="gate-type" class="mt-1 w-full p-2 border rounded">
+                  <option value="swing">Swing</option>
+                  <option value="slide">Slide</option>
+                </select>
+              </div>
+              <div>
+                <label for="gate-width" class="block text-sm text-gray-700">Gate Width (ft)</label>
+                <select id="gate-width" class="mt-1 w-full p-2 border rounded">
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                  <option value="5">5</option>
+                  <option value="6">6</option>
+                  <option value="7">7</option>
+                  <option value="8">8</option>
+                  <option value="9">9</option>
+                  <option value="10">10</option>
+                  <option value="11">11</option>
+                  <option value="12">12</option>
+                  <option value="13">13</option>
+                  <option value="14">14</option>
+                  <option value="15">15</option>
+                  <option value="16">16</option>
+                  <option value="17">17</option>
+                  <option value="18">18</option>
+                  <option value="19">19</option>
+                  <option value="20">20</option>
+                </select>
+              </div>
+            </div>
+            <label class="inline-flex items-center">
+              <input type="checkbox" id="gate-auto" class="form-checkbox text-green-600" />
+              <span class="ml-2">Automation</span>
+            </label>
+          </fieldset>
+        </div>
+
+        <button type="button" id="update-btn" class="w-full bg-green-600 text-white py-2 px-4 rounded-lg hover:bg-green-700 transition">Update Estimate</button>
       </form>
 
       <aside id="summary" class="mt-8 md:mt-0 md:w-1/3 bg-gray-50 p-6 rounded-xl shadow space-y-2" aria-live="polite">
         <h2 class="text-xl font-semibold mb-4">Cost Summary</h2>
         <p>Materials: $<span data-materials>0.00</span></p>
         <p class="font-bold">Total: $<span data-total>0.00</span></p>
-        <p class="mt-4 text-sm text-gray-600">Posts needed: <span data-posts>0</span>, Rails needed: <span data-rails>0</span></p>
       </aside>
     </div>
   </main>

--- a/mgfencing-2/js/estimator.js
+++ b/mgfencing-2/js/estimator.js
@@ -6,10 +6,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const heightValue = document.getElementById('height-value');
   const chainOptions = document.getElementById('chainlink-options');
   const vinylOptions = document.getElementById('vinyl-options');
+  const hasGates = document.getElementById('has-gates');
   const gateSection = document.getElementById('gate-section');
   const gateCount = document.getElementById('gate-count');
   const gateWidth = document.getElementById('gate-width');
   const gateAuto = document.getElementById('gate-auto');
+  const updateBtn = document.getElementById('update-btn');
   const summary = document.getElementById('summary');
   const lengthError = document.getElementById('length-error');
 
@@ -23,16 +25,21 @@ document.addEventListener('DOMContentLoaded', () => {
     const val = category.value;
     chainOptions.classList.toggle('hidden', val !== 'chainlink');
     vinylOptions.classList.toggle('hidden', val !== 'vinyl');
-    gateSection.classList.toggle('hidden', !['privacy','vinyl','chainlink','wrought_iron'].includes(val));
+    gateSection.classList.toggle('hidden', !hasGates.checked);
   }
   category.addEventListener('change', () => { toggleSections(); update(); });
+  if (hasGates) {
+    hasGates.addEventListener('change', () => { toggleSections(); update(); });
+  }
 
-  heightRange.addEventListener('input', () => {
-    heightValue.textContent = `${heightRange.value}ft`;
-    update();
+  ['input', 'change'].forEach(evt => {
+    heightRange.addEventListener(evt, update);
   });
 
-  [lengthInput, gateCount, gateWidth, gateAuto, document.getElementById('slats'), document.getElementById('vinyl-slats'), document.getElementById('chain-color'), document.getElementById('gate-type')].forEach(el => {
+  [lengthInput, hasGates, gateCount, gateWidth, gateAuto,
+    document.getElementById('slats'), document.getElementById('vinyl-slats'),
+    document.getElementById('chain-color'), document.getElementById('gate-type')
+  ].forEach(el => {
     if (el) el.addEventListener('input', update);
   });
 
@@ -40,8 +47,12 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     update();
   });
+  if (updateBtn) {
+    updateBtn.addEventListener('click', update);
+  }
 
   function update() {
+    heightValue.textContent = `${heightRange.value}ft`;
     const length = parseFloat(lengthInput.value);
     if (!length || length < 10) {
       lengthError.textContent = 'Minimum perimeter is 10 ft';
@@ -49,8 +60,6 @@ document.addEventListener('DOMContentLoaded', () => {
       lengthInput.setAttribute('aria-invalid', 'true');
       summary.querySelector('[data-materials]').textContent = '0.00';
       summary.querySelector('[data-total]').textContent = '0.00';
-      summary.querySelector('[data-posts]').textContent = '0';
-      summary.querySelector('[data-rails]').textContent = '0';
       return;
     }
     lengthError.classList.add('hidden');
@@ -58,9 +67,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const product = category.value;
     const info = prices.products[product] || {};
-    const materialRate = info.material || 0;
+    let materialRate = info.material || 0;
     const height = parseInt(heightRange.value, 10) || 4;
-    const mult = {3:0.75,4:1,5:1.25,6:1.5}[height] || 1;
+    const mult = height / 4;
+    if (product === 'chainlink') {
+      const color = document.getElementById('chain-color').value;
+      if (color && color !== 'galvanized' && info.materialColored) {
+        materialRate = info.materialColored;
+      }
+    }
     let materialCost = materialRate * mult * length;
 
     if (product === 'chainlink' && document.getElementById('slats').checked) {
@@ -70,25 +85,23 @@ document.addEventListener('DOMContentLoaded', () => {
       materialCost += 7 * mult * length;
     }
 
-    const gates = parseInt(gateCount.value) || 0;
-    const gateWidthVal = parseFloat(gateWidth.value) || 0;
-    if (gates > 0) {
-      const gateRate = info.gate || 0;
-      materialCost += gates * gateWidthVal * gateRate;
-      if (gateAuto.checked) {
-        materialCost += gates * 1000;
+    if (hasGates && hasGates.checked) {
+      const gates = parseInt(gateCount.value) || 0;
+      const gateWidthVal = parseFloat(gateWidth.value) || 0;
+      if (gates > 0) {
+        const gateRate = info.gate || 0;
+        materialCost += gates * gateWidthVal * height * gateRate;
+        if (gateAuto.checked) {
+          materialCost += gates * 1000;
+        }
       }
     }
 
-    const posts = Math.ceil(length / 8) + 1;
-    const rails = posts * 2;
     const tax = materialCost * (prices.taxRate || 0);
     const total = materialCost + tax;
 
     summary.querySelector('[data-materials]').textContent = materialCost.toFixed(2);
     summary.querySelector('[data-total]').textContent = total.toFixed(2);
-    summary.querySelector('[data-posts]').textContent = posts;
-    summary.querySelector('[data-rails]').textContent = rails;
   }
 
   toggleSections();


### PR DESCRIPTION
## Summary
- Remove post/rail counts from fence estimator summary
- Support heights up to 8ft and scale cost by height
- Add pricing for colored chain-link and gate width options with fence-height-based costs
- Always present gate controls so any fence type can include gates
- Switch update button to avoid page refresh and keep gate question visible
- Fix height slider so it displays current value and limits selection to 4–8 ft
- Streamline gate fields with a bordered fieldset and two-column layout for cleaner UI

## Testing
- `node --check mgfencing-2/js/estimator.js`


------
https://chatgpt.com/codex/tasks/task_e_68912c32bd0c8333aa768f8aaabec099